### PR TITLE
Versioning: update semver link URL

### DIFF
--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,7 +1,7 @@
 ## Versioning
 We are now introducing versioning so users can stick to specific versions of software. As we are dealing with three upstream sources (nginx, php and alpine) plus our own scripts this all gets a little complex, but this document will provide a definitive source of tags and versions.
 
-We will use the [semver](http://ricostacruz.com/cheatsheets/semver.html) style notation for versioning:
+We will use the [semver](https://devhints.io/semver) style notation for versioning:
 
 >This follows the format MAJOR.MINOR.PATCH (eg, 1.2.6)
 >


### PR DESCRIPTION
http://ricostacruz.com/cheatsheets is now https://devhints.io :) (The old URL's are still accessible for now.)

See: https://devhints.io/semver